### PR TITLE
Add option to ignore folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you want to force suggestions you can press <kbd>ctrl</kbd> + <kbd>space</kbd
 - `importMagic.multiline`: Imports can be aligned with `backlslash` or `parentheses`. By-default this option is undefined. Alignment will be applied with iSort defaults.
 - `importMagic.indentWithTabs`: Make tab indents instead four spaces. By-default this option undefined.
 - `importMagic.skipTestFolders`: Do not indexing test folders in your project. It's true by default.
+- `importMagic.ignoreFolders`: Do not indexing specific folders in your project.
 
 
 ## Install notes
@@ -56,6 +57,15 @@ If you want to force suggestions you can press <kbd>ctrl</kbd> + <kbd>space</kbd
 
 ## Contributing
 - I'll appreciate any merge request that will do this project better
+
+To get this extension build locally do:
+
+- git submodule init
+- git submodule update
+- npm install -g typescript vsce
+- vsce package
+
+Now install the build visx package in vscode. 
 
 
 ## License 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "license": "MIT",
     "engines": {
-        "vscode": "^1.33.0"
+        "vscode": "^1.45.0"
     },
     "categories": [
         "Other"
@@ -90,6 +90,12 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Skip test folders on indexing",
+                    "scope": "resource"
+                },
+                "importMagic.ignoreFolders": {
+                    "type": "array",
+                    "default": true,
+                    "description": "Folders to skip on indexing",
                     "scope": "resource"
                 }
             }

--- a/pythonFiles/src/extended_isort.py
+++ b/pythonFiles/src/extended_isort.py
@@ -1,7 +1,7 @@
 import os
 import locale
 
-from difflib import unified_diff, SequenceMatcher
+from difflib import SequenceMatcher
 
 # from pathlib import Path
 try:
@@ -12,9 +12,12 @@ except ImportError:
 
 from isort import settings
 from isort.isort import _SortImports
-from isort.compat import get_settings_path, resolve, \
-    determine_file_encoding, read_file_contents
-
+from isort.compat import (
+    get_settings_path,
+    resolve,
+    determine_file_encoding,
+    read_file_contents
+)
 
 class SortImportsException(Exception):
     pass
@@ -81,9 +84,11 @@ class ExtendedSortImports(object):
             return []
 
         extension = file_name.split('.')[-1] if file_name else "py"
-        self.sorted_imports = _SortImports(file_contents=file_contents,
-                                           config=self.config,
-                                           extension=extension)
+        self.sorted_imports = _SortImports(
+            file_contents=file_contents,
+            config=self.config,
+            extension=extension
+        )
         self.output = self.sorted_imports.output
 
         # END. compare file_contents vs self.output

--- a/pythonFiles/src/extension.py
+++ b/pythonFiles/src/extension.py
@@ -18,6 +18,7 @@ class Extension(object):
 
         self._workspace_path = None  # .isort.cfg could be placed there
         self._paths = []
+        self._ignore_folders = []
         self._skip_tests = True
         self._temp_path = None
         self._index_manager = None
@@ -62,6 +63,16 @@ class Extension(object):
         self._paths = value
 
     @property
+    def ignore_folders(self):
+        return self._ignore_folders
+
+    @ignore_folders.setter
+    def ignore_folders(self, value):
+        if not isinstance(value, list):
+            raise TypeError('ignore folders must be list')
+        self._ignore_folders = value
+
+    @property
     def workspace_path(self):
         return self._workspace_path
 
@@ -93,6 +104,7 @@ class Extension(object):
             raise Exception('Restart to reconfigure it')
 
         self.paths = kwargs.get('paths', [])
+        self.ignore_folders = kwargs.get('ignoreFolders', [])
         self.skip_tests = bool(kwargs.get('skipTest', True))
         self.temp_path = kwargs.get('tempPath')
         self.workspace_path = kwargs.get('workspacePath')
@@ -137,7 +149,9 @@ class Extension(object):
                     package_path = os.path.sep.join(parts[:-1])
                     prefiexes.append(package_path)
 
-        idx = FileIndexer(self.paths, prefiexes, self.skip_tests)
+        idx = FileIndexer(
+            self.paths, prefiexes, self.skip_tests, self.ignore_folders
+        )
         idx.build(self._report_scan_progress)
 
         self._index_manager.remove_from_index(idx)
@@ -157,7 +171,7 @@ class Extension(object):
         
         self._index_manager.recreate_index()
         
-        idx = DirIndexer(self.paths, self.skip_tests)
+        idx = DirIndexer(self.paths, self.skip_tests, self.ignore_folders)
         idx.build(self._report_scan_progress)
         total_items = idx.get_power() or 1
 

--- a/pythonFiles/src/index_manager.py
+++ b/pythonFiles/src/index_manager.py
@@ -57,7 +57,11 @@ class IndexManager(object):
 
     def open(self):
         # Quickly count files in project (include system files)
-        idx = QuickIndexer(self._extension.paths, self._extension.skip_tests)
+        idx = QuickIndexer(
+            self._extension.paths,
+            self._extension.skip_tests,
+            self._extension.ignore_folders
+        )
         idx.build()
 
         if self._read_checksum() != self._make_index_hashsum(idx.total_files):

--- a/pythonFiles/src/indexer.py
+++ b/pythonFiles/src/indexer.py
@@ -6,22 +6,31 @@ from src.symbol_index import ExtendedSymbolIndex
 
 
 class Indexer(object):  # Manager for ExtendedSymbolIndex
-    def __init__(self, paths, skip_tests=True):
+    def __init__(self, paths, skip_tests=True, ignore_folders=None):
         self.target_prefixes = None
         self.affected_files = set()  # Uses when target_prefixes was set
         self._last_report_time = 0
         self._report_listener = None
         self.total_files = 0
 
-        if skip_tests:
+        if ignore_folders is not None:
+            start_regex = (
+                r'\btest[s]?|test[s]?\b' if skip_tests else r''
+            )
+            folder_regex = [
+                r'\b' + folder + r'\b' for folder in ignore_folders
+            ]
+            regex = r"|".join([start_regex, *folder_regex])
+            self.blacklist_re = re.compile(regex)
+        elif skip_tests:
             self.blacklist_re = importmagic.index.DEFAULT_BLACKLIST_RE
         else:
             self.blacklist_re = re.compile(r'^$')
 
         self.paths = list(set(paths + sys.path))
         
-        # Remove this plugin pathes
         for s in list(self.paths):
+            # Remove this plugin paths
             if 'vscode-importmagic' in s or s == '':
                 self.paths.remove(s)
         
@@ -77,17 +86,17 @@ class Indexer(object):  # Manager for ExtendedSymbolIndex
 
 
 class DirIndexer(Indexer):
-    def __init__(self, paths, skip_tests=True):
-        super().__init__(paths, skip_tests)
+    def __init__(self, paths, skip_tests=True, ignore_folders=None):
+        super().__init__(paths, skip_tests, ignore_folders)
 
 
 class FileIndexer(Indexer):
-    def __init__(self, paths, prefixes, skip_tests=True):
-        super().__init__(paths, skip_tests)
+    def __init__(self, paths, prefixes, skip_tests=True, ignore_folders=None):
+        super().__init__(paths, skip_tests, ignore_folders)
         self.target_prefixes = prefixes
 
 
 class QuickIndexer(Indexer):
-    def __init__(self, paths, skip_tests=True):
-        super().__init__(paths, skip_tests)
+    def __init__(self, paths, skip_tests=True, ignore_folders=None):
+        super().__init__(paths, skip_tests, ignore_folders)
         self.target_prefixes = []

--- a/src/common/settings.ts
+++ b/src/common/settings.ts
@@ -15,6 +15,7 @@ export const IS_WINDOWS = /^win/.test(process.platform);
 
 export class Settings implements ISettings, vscode.Disposable {
     public extraPaths: string[] = [];
+    public ignoreFolders: string[] = [];
     private multiline: string = null;
     private maxColumns: number = null;
     private indentWithTabs: boolean = null;
@@ -64,6 +65,7 @@ export class Settings implements ISettings, vscode.Disposable {
         this.maxColumns = pluginSettings.get('maxColumns');
         this.indentWithTabs = pluginSettings.get('indentWithTabs');
         this.skipTestFolders = pluginSettings.get('skipTestFolders');
+        this.ignoreFolders = pluginSettings.get('ignoreFolders');
 
         if (!this.maxColumns) {
             const rulers = editorSettings.get<number[]>('rulers', []);

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -49,6 +49,7 @@ export interface IStyle {
 export interface ISettings {
     pythonPath: string;
     extraPaths: string[];
+    ignoreFolders: string[];
     style: IStyle;
     skipTestFolders: boolean;
 }

--- a/src/importMagic.ts
+++ b/src/importMagic.ts
@@ -77,6 +77,7 @@ export interface ICommand<T extends ICommandResult> {
 
 interface ICommandConfigure<T extends ICommandResult> extends ICommand<T> {
     paths: string[];
+    ignoreFolders: string[];
     workspacePath: string;
     skipTest: boolean;
     style: object;
@@ -166,6 +167,7 @@ export class ImportMagic implements vscode.Disposable {
             paths: this.settings.extraPaths,
             workspacePath: this.workspacePath,
             skipTest: this.settings.skipTestFolders,
+            ignoreFolders: this.settings.ignoreFolders,
             tempPath: this.storagePath,
             workspaceName: this.workspaceName,
             style: this.settings.style


### PR DESCRIPTION
A warning first: Merging the current state of the PR would introduce a bug, which I wasn't able to fix myself.

This PR addresses #21 

Given that multiple people (including myself) have vast amount of files and folders in their workspace and not all of them needed to be scanned by import magic this option allows to filter folders. It adds a configuration ignore_folders taking an array of folder names that should be ignored. This as well comes in handy to get rid of all suggestions for `__pycache__` folders. 

The way this is achieved is by taking the indexers `blacklist_re` and adding `|\bfolder_name\b` for each `folder_name` handed by the configuration. (This might lead to issues when this list is getting exhaustively long, but I think that is far of in the future 😉)

As this is as well my first time contributing anything to a VSCode extension, I added some minimal hints to the README, so noobs like me have an easier time getting started 😉 

Due to my limited ability with developing extensions and not knowing how to write test for them there is one bug I could not resolve. I hope that someone else can pinpoint me in the direction where I need to search for it. When changing anything in the configuration, the extension breaks and doesn't work until I do `Reload Window`. Furthermore, the index is then only rebuild if I delete the index file.

I hope that this still provides a useful contribution even though it has its issues 👍 
